### PR TITLE
Refactor passwordstore-ldap namespace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 vendor/
 .idea/
+/nbproject/
+auth.json

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
   },
   "autoload": {
     "psr-4": {
-      "Sil\\IdpPw\\PasswordStore\\": "src/"
+      "Sil\\IdpPw\\PasswordStore\\Ldap\\": "src/"
     }
   }
 }

--- a/src/Ldap.php
+++ b/src/Ldap.php
@@ -1,5 +1,5 @@
 <?php
-namespace Sil\IdpPw\PasswordStore;
+namespace Sil\IdpPw\PasswordStore\Ldap;
 
 use Adldap\Adldap;
 use Adldap\Connections\Provider;

--- a/tests/LdapTest.php
+++ b/tests/LdapTest.php
@@ -3,7 +3,7 @@ namespace tests;
 
 require __DIR__ . '/../vendor/autoload.php';
 
-use Sil\IdpPw\PasswordStore\Ldap;
+use Sil\IdpPw\PasswordStore\Ldap\Ldap;
 
 class LdapTest extends \PHPUnit_Framework_TestCase
 {


### PR DESCRIPTION
Refactor passwordstore-ldap namespace to include Ldap to prevent collision with new IdBroker passwordstore.