### PR TITLE
Support `unicodePwd` field

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,8 @@
     "php": ">=7.0",
     "roave/security-advisories": "dev-master",
     "silinternational/idp-pw-api-common": "^1.0",
-    "adldap2/adldap2": "dev-master"
+    "adldap2/adldap2": "dev-master",
+    "ext-iconv": "*"
   },
   "require-dev": {
     "phpunit/phpunit": "~4.0"

--- a/src/Ldap.php
+++ b/src/Ldap.php
@@ -193,6 +193,9 @@ class Ldap extends Component implements PasswordStoreInterface
          */
         $this->assertUserNotDisabled($user);
 
+        if ($this->userPasswordAttribute === 'unicodePwd') {
+            $password = $this->encodeForUnicodePwdField($password);
+        }
 
         /*
          * Update password
@@ -263,6 +266,28 @@ class Ldap extends Component implements PasswordStoreInterface
         }
 
         return $this->getMeta($employeeId);
+    }
+    
+    /**
+     * Encode the given password as necessary for use in the `unicodePwd` field.
+     *
+     * For details, see
+     * https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-adts/6e803168-f140-4d23-b2d3-c3a8ab5917d2
+     *
+     * @param $password
+     * @return false|string
+     * @throws \Exception
+     */
+    protected function encodeForUnicodePwdField($password)
+    {
+        $encodedPassword = iconv('UTF-8', 'UTF-16LE', '"' . $password . '"');
+        if ($encodedPassword === false) {
+            throw new \Exception(
+                'Did not set password: Cannot encode it properly.',
+                1554296385
+            );
+        }
+        return $encodedPassword;
     }
 
     public function matchesRequiredAttributes($user)


### PR DESCRIPTION
**Added:**
- Will properly encode passwords for storing in the `unicodePwd` field when applicable.